### PR TITLE
chore(mongodb): use bitnamilegacy repo

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -18,5 +18,5 @@ dependencies:
     condition: minio.enabled
   - name: mongodb
     repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
-    version: 10.19.0
+    version: 10.19.0 # TODO: when updating the chart, relax the constraint on the tag of mongodb image
     condition: mongodb.internal_db.enabled

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -18,7 +18,8 @@ api:
   # Note, you must set up mongodb in order to use the API.
   enabled: true
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -87,7 +88,8 @@ api:
   ingress:
     ingressClassName: nginx
     labels: {}
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/tls-acme: "true"
     hosts:
       - host: api.chart-example.local
@@ -109,7 +111,8 @@ dashboard:
   # If you have no need for the Dashboard service, you can set this to false to exclude it.
   enabled: true
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -171,7 +174,8 @@ dashboard:
     enabled: true
     ingressClassName: nginx
     labels: {}
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/tls-acme: "true"
     hosts:
       - host: dashboard.chart-example.local
@@ -201,7 +205,8 @@ director:
 
   replicas: 1
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -290,7 +295,8 @@ director:
     enabled: true
     ingressClassName: nginx
     labels: {}
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/tls-acme: "true"
     hosts:
       - host: director.chart-example.local
@@ -301,6 +307,12 @@ director:
     #      - chart-example.local
 
 mongodb:
+  image:
+    # Fix the repository after Bitnami Image deprecation
+    # In case of Chart upgrade, make sure the new image is available
+    repository: bitnamilegacy/mongodb
+    tag: "4.4.6" # The current image is so old that the complete tag is not available on bitnamilegacy registry # TODO: when updating the chart, relax this constraint
+
   # You need to ensure that director.environmentVariables.executionDriver is set to "../execution/mongo/driver" if you want the director to use mongodb.
   mongoConnectionString: "mongodb://sorry-cypress-mongo.back.padoa"
 
@@ -358,7 +370,8 @@ s3:
     enabled: false
     ingressClassName: nginx
     labels: {}
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/tls-acme: "true"
       # nginx.ingress.kubernetes.io/upstream-vhost: <bucket>.s3-website-<region>.amazonaws.com
       # nginx.ingress.kubernetes.io/enable-cors: "true"
@@ -381,7 +394,7 @@ minio:
   # Ref: https://docs.sorry-cypress.dev/configuration/director-configuration/minio-configuration
   endpoint: storage.yourdomain.com
   url: http://storage.yourdomain.com
-  readUrlPrefix: ''
+  readUrlPrefix: ""
 
   defaultBucket:
     enabled: true
@@ -393,13 +406,13 @@ minio:
 azureBlobStorage:
   containerName: sorry-cypress
   uploadUrlExpiryInHours: 24
-  existingSecret: ''
-  fullnameOverride: ''
+  existingSecret: ""
+  fullnameOverride: ""
 
 runCleaner:
-# Optionally integrate the Sorry Cypress Run Cleaner to remove old runs from the database.
-# You will need to set up your S3/Minio lifecycle management to delete objects from your bucket.
-# https://github.com/sendible-labs/sorry-cypress-run-cleaner
+  # Optionally integrate the Sorry Cypress Run Cleaner to remove old runs from the database.
+  # You will need to set up your S3/Minio lifecycle management to delete objects from your bucket.
+  # https://github.com/sendible-labs/sorry-cypress-run-cleaner
   enabled: false
   image:
     repository: "ghcr.io/sendible-labs/sorry-cypress-run-cleaner"
@@ -407,13 +420,12 @@ runCleaner:
   # Keep the last 200 days worth of runs.
   daysToKeep: 200
   # Run every morning at 1am by default.
-  schedule: '0 1 * * *'
+  schedule: "0 1 * * *"
   # Cluster domain to resolve api host correctly
-  clusterDomain: 'cluster.local'
+  clusterDomain: "cluster.local"
 
   # Name of the existing priority class to be used by pod(s)
   priorityClassName: ""
-
 
 cleanerFailedRuns:
   enabled: true
@@ -428,7 +440,7 @@ cleanerFailedRuns:
   backoff_limit: 20
   image:
     repository: mongo
-    tag: '4.4.6'
+    tag: "4.4.6"
     pullPolicy: IfNotPresent
   service:
     port: 27017
@@ -446,7 +458,7 @@ cleanerSuccessfulRuns:
   backoff_limit: 20
   image:
     repository: mongo
-    tag: '4.4.6'
+    tag: "4.4.6"
     pullPolicy: IfNotPresent
   service:
     port: 27017
@@ -454,7 +466,6 @@ cleanerSuccessfulRuns:
 serviceAccount:
   create: false
   name:
-  
 
 imagePullSecrets: []
 # An optional array of imagePullSecrets that are used to download images from a private registry


### PR DESCRIPTION
The tag mongodb:4.4.6-debian-10-r8 referenced is so old that is has not been copied to bitnamilegacy registry. We temporarely override to use mongodb:4.4.6, which is 4.4.6-debian-10-r44

Diff is 

```diff
<           image: docker.io/bitnami/mongodb:4.4.6-debian-10-r8
---
>           image: docker.io/bitnamilegacy/mongodb:4.4.6
```

Checklist:

* [] I have increased the chart version.
* [] I have updated the chart readme.
* [] I have updated the chart changelog.
* [] I have written CI tests for my change.
